### PR TITLE
Remove 8 unnecessary stubbings in PiwikTrackerTest.java

### DIFF
--- a/src/test/java/org/matomo/java/tracking/PiwikTrackerTest.java
+++ b/src/test/java/org/matomo/java/tracking/PiwikTrackerTest.java
@@ -143,7 +143,7 @@ public class PiwikTrackerTest {
     doReturn(client).when(piwikTracker).getHttpAsyncClient();
     doReturn(PARAMETERS).when(request).getParameters();
     doReturn(response).when(future).get();
-    doReturn(true).when(future).isDone();
+
     doReturn(future).when(client)
       .execute(argThat(new CorrectGetRequest("http://test.com?parameterName=parameterValue")), any());
 
@@ -273,9 +273,9 @@ public class PiwikTrackerTest {
       HttpClient client = mock(HttpClient.class);
       PiwikRequest request = mock(PiwikRequest.class);
 
-      doReturn(PARAMETERS).when(request).getParameters();
+
       requests.add(request);
-      doReturn(client).when(piwikTracker).getHttpClient();
+
 
       piwikTracker.sendBulkRequest(requests, "1");
       fail("Exception should have been thrown.");
@@ -324,7 +324,7 @@ public class PiwikTrackerTest {
     HttpResponse response = mock(HttpResponse.class);
     Future<HttpResponse> future = mock(Future.class);
     doReturn(response).when(future).get();
-    doReturn(true).when(future).isDone();
+
 
     doReturn(future).when(piwikTracker).sendBulkRequestAsync(requests);
 
@@ -341,9 +341,9 @@ public class PiwikTrackerTest {
       CloseableHttpAsyncClient client = mock(CloseableHttpAsyncClient.class);
       PiwikRequest request = mock(PiwikRequest.class);
 
-      doReturn(PARAMETERS).when(request).getParameters();
+
       requests.add(request);
-      doReturn(client).when(piwikTracker).getHttpAsyncClient();
+
 
       piwikTracker.sendBulkRequestAsync(requests, "1");
       fail("Exception should have been thrown.");
@@ -360,7 +360,7 @@ public class PiwikTrackerTest {
     HttpResponse response = mock(HttpResponse.class);
     Future<HttpResponse> future = mock(Future.class);
     doReturn(response).when(future).get();
-    doReturn(true).when(future).isDone();
+
 
     doReturn(PARAMETERS).when(request).getParameters();
     requests.add(request);
@@ -379,7 +379,7 @@ public class PiwikTrackerTest {
     HttpResponse response = mock(HttpResponse.class);
     Future<HttpResponse> future = mock(Future.class);
     doReturn(response).when(future).get();
-    doReturn(true).when(future).isDone();
+
 
     doReturn(PARAMETERS).when(request).getParameters();
     requests.add(request);
@@ -439,3 +439,4 @@ public class PiwikTrackerTest {
     assertNotNull(httpClient);
   }
 }
+


### PR DESCRIPTION
In our analysis of the project, we observed that there are 6 tests: PiwikTrackerTest.testSendBulkRequestAsync_Iterable, PiwikTrackerTest.testSendBulkRequestAsync_Iterable_StringFF, PiwikTrackerTest.testSendBulkRequestAsync_Iterable_StringFT, PiwikTrackerTest.testSendBulkRequestAsync_Iterable_StringTT, PiwikTrackerTest.testSendBulkRequest_Iterable_StringTT, PiwikTrackerTesttestSendRequestAsync contain 8 unnecessary stubbings in total. Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbings.